### PR TITLE
Background

### DIFF
--- a/P64_bg.svg
+++ b/P64_bg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1004">
+	<title>C64</title>
+	<rect fill="#4343ed" stroke="#a9a9ff" stroke-width="75" x="1" y="1" width="1920" height="1004" />
+</svg>

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ A Commodore 64 Experience for Windows Terminal
 4. EDIT <filename> [Shorthand for nano]
 
 ### PREREQUISITES
-1. Windows Terminal
-2. PowerShell 7
-3. C64 font Download Here https://www.dafont.com/commodore-64.font © Devin Cook
+1. [Windows Terminal](https://aka.ms/terminal) © Microsoft
+2. [PowerShell 7](https://github.com/PowerShell/PowerShell/releases/latest) © Microsoft
+3. [C64 font](https://www.dafont.com/commodore-64.font) © Devin Cook
 
 ### INSTALLATION
 1. Clone the repo
@@ -26,5 +26,21 @@ A Commodore 64 Experience for Windows Terminal
 3. Change the places in your WT Settings where it says [INSERT YOUR REPO PATH HERE]
 4. Start Windows Terminal open the WT64 teminal
 
-Download Font Here
-https://www.dafont.com/commodore-64.font © Devin Cook
+### BACKGROUND
+The standard background doesn't always scale properly, you can use the `P64_bg.svg` to create a new background that will have a 75px border and fit your screenresolution by followin these steps:
+**1. Edit SVG**
+Open the SVG in any text-editor and edit the width and height on the first in the viewBox & third line in the width and height attributes
+It should be your screen width and your screen height minus taskbar (40px) and window header (36px)
+If you don't use the taskbar or have it on the side of your screen adjust the height and width in the SVG accordingly
+**2. Convert the SVG to PNG**
+Open the SVG in an SVG capable photo-editor and save as P64_bg.png.
+I use photopea.com for this, online, easy & free!
+* Drag SVG onto center area or use `File > Open...`
+* Select `File > Export as > PNG`
+* Click `Save`
+* If necessary rename the PNG-file to P64_bg.png
+
+**3. Replace the background**
+Replace the current background with this newly created one by overwriting the current one in the location you have stored WT64
+**4. Done!**
+Restart Windows Terminal and see the new background in action


### PR DESCRIPTION
The provided background didn't scale properly for me on my 1920x1080 screen.
In the maximized version the cursor wasn't visible as it was on the border.
In the default sized unmaximized version when opening Terminal the cursor was correctly placed but the window was not wide enough causing ugly linebreaks.

So I created a new background which scales properly on a 1920x1080 screen.

I've also created a SVG so people can easily create a background, which always creates a 75px border, for themselves and added instructions to the readme.